### PR TITLE
Add Terraform workspace for test-workspace

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: TerraformWorkspace
+metadata:
+  name: test-workspace
+  annotations:
+    github.com/project-slug: navneet-bairwal/learn-terraform-run-triggers-network
+    backstage.io/source-location: url:https://github.com/navneet-bairwal/learn-terraform-run-triggers-network
+    github.com/workflows-in-repo: 'true'
+spec:
+  type: terraform-workspace
+  owner: platform-team
+  system: terraform
+  lifecycle: experimental 


### PR DESCRIPTION
This PR adds a new Terraform workspace configuration.

- Name: test-workspace
- Environment: dev
- AWS Region: us-west-2
- Terraform Version: 1.7.0
- Working Directory: .

Please review the configuration and merge if everything looks correct.
